### PR TITLE
Disable Renovate dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "dependencyDashboard": false
 }


### PR DESCRIPTION
## Summary
- add a repo-level Renovate config
- disable the dependency dashboard issue by setting  to 

## Testing
- not run (configuration-only change)