### PR TITLE
fix: align release tags with pub publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 name: ci
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,15 @@
+name: Publish to pub.dev
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  publish:
+    permissions:
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    # with:
+    #   environment: pub.dev
+    #   working-directory: .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,7 @@ If behavior changes, update both:
 - `release-please` configuration lives in `release-please-config.json`.
 - The current released version baseline lives in `.release-please-manifest.json`.
 - Release tags should stay in `v<version>` format to match pub.dev trusted publishing.
+- `.github/workflows/publish.yml` owns tag-triggered publishing to pub.dev.
 - Release automation uses Octo STS instead of a long-lived PAT.
 - The trust policy for release automation lives in `.github/chainguard/release-please.sts.yaml`.
 - Keep the trust policy narrowly scoped to the `release-please` workflow on the `main` branch of this repository unless behavior intentionally changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,8 @@ When that release PR is merged, `release-please` creates a GitHub release and pu
 
 For this repository, the tag format is `v1.2.3`. That should match the tag pattern configured for pub.dev trusted publishing.
 
+Publishing to pub.dev is handled by `.github/workflows/publish.yml`, which is triggered by tags matching `v[0-9]+.[0-9]+.[0-9]+`.
+
 ### GitHub Token
 
 Release automation uses Octo STS instead of a long-lived PAT.
@@ -61,6 +63,15 @@ The release workflow exchanges the GitHub Actions OIDC token for a short-lived G
 The trust policy is intentionally bound to the `release-please` workflow on the `main` branch and to a dedicated OIDC audience so other workflows cannot reuse the same Octo STS identity by accident.
 
 This keeps repo write credentials ephemeral while still allowing release tags to trigger downstream publish workflows.
+
+### pub.dev Setup
+
+In the `wario` package admin page on pub.dev, automated publishing from GitHub Actions should be configured for:
+
+- repository: `JustinBeckwith/wario`
+- tag pattern: `v{{version}}`
+
+If you want an approval gate before publishing, require the `pub.dev` GitHub Actions environment on pub.dev and then uncomment the `environment: pub.dev` line in `.github/workflows/publish.yml`.
 
 ### Commit Message Format
 
@@ -85,6 +96,7 @@ Commits like `docs:`, `test:`, and `chore:` can still be included in release PRs
 - `lib/utils.dart`: GitHub repo discovery and auth lookup
 - `test/`: CLI, config, sync, exec, and auth coverage
 - `.github/chainguard/release-please.sts.yaml`: Octo STS trust policy for release automation
+- `.github/workflows/publish.yml`: pub.dev trusted publishing workflow triggered by release tags
 - `.github/workflows/release-please.yml`: release PR and GitHub release automation
 - `release-please-config.json`: release-please package configuration
 - `.release-please-manifest.json`: current released version tracked by release-please

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,8 @@
   "packages": {
     ".": {
       "release-type": "dart",
-      "include-v-in-tag": true
+      "include-v-in-tag": true,
+      "include-component-in-tag": false
     }
   }
 }


### PR DESCRIPTION
## Summary
- add the missing pub.dev trusted publishing workflow
- configure release-please to use plain `v<version>` tags
- update CI push triggers to follow `main`

## Notes
- pub.dev should be configured for repository `JustinBeckwith/wario` with tag pattern `v{{version}}`
- the existing `wario-v0.2.0` tag will not match that pattern

## Testing
- validated workflow YAML parses
- validated release-please config JSON parses